### PR TITLE
FNA update

### DIFF
--- a/Illuminant/Illuminant.SDL2.csproj
+++ b/Illuminant/Illuminant.SDL2.csproj
@@ -54,13 +54,13 @@
       <Project>{140FFD8A-4ECD-4BBC-AE81-FCC21F9ED36A}</Project>
       <Name>Squared.Render.SDL2</Name>
     </ProjectReference>
-    <ProjectReference Include="..\MonoGame\MonoGame.Framework\MonoGame.Framework.SDL2.csproj">
-      <Project>{35253CE1-C864-4CD3-8249-4D1319748E8F}</Project>
-      <Name>MonoGame.Framework.SDL2</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Squared\Util\Squared.Util.SDL2.csproj">
       <Project>{D3A95FBF-A1C5-45D0-839F-B155D7B10272}</Project>
       <Name>Squared.Util.SDL2</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FNA\FNA.csproj">
+      <Project>{35253CE1-C864-4CD3-8249-4D1319748E8F}</Project>
+      <Name>FNA</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Illuminant/LightingQuery.cs
+++ b/Illuminant/LightingQuery.cs
@@ -156,8 +156,7 @@ namespace Squared.Illuminant {
                 options.MaxDegreeOfParallelism = 1;
 
             _ObstructionsByLight.Clear();
-#if SDL2
-            // Parallel is Satan -flibit
+#if SDL2 // Parallel is Satan -flibit
             foreach (LightSource ls in Environment.LightSources)
             {
                 LineGeneratorContext ctx = new LineGeneratorContext(Environment.Obstructions.Count * 2);

--- a/Illuminant/LightingRenderer.cs
+++ b/Illuminant/LightingRenderer.cs
@@ -346,7 +346,6 @@ namespace Squared.Illuminant {
                     ), dBegin, dEnd
                 ));
 
-#if !SDL2
                 materials.Add(IlluminantMaterials.PointLightExponentialRampTexture = new DelegateMaterial(
                     PointLightMaterialsInner[2] = new Squared.Render.EffectMaterial(
                         content.Load<Effect>("Illumination"), "PointLightExponentialRampTexture"
@@ -358,7 +357,6 @@ namespace Squared.Illuminant {
                         content.Load<Effect>("Illumination"), "PointLightLinearRampTexture"
                     ), dBegin, dEnd
                 ));
-#endif
 
                 materials.Add(IlluminantMaterials.VolumeTopFace = new DelegateMaterial(
                     new Squared.Render.EffectMaterial(
@@ -388,11 +386,7 @@ namespace Squared.Illuminant {
 
             materials.Add(IlluminantMaterials.Shadow = new DelegateMaterial(
                 ShadowMaterialInner = new Squared.Render.EffectMaterial(
-#if SDL2
-                    content.Load<Effect>("Shadow"), "Shadow"
-#else
                     content.Load<Effect>("Illumination"), "Shadow"
-#endif
                 ),
                 new[] {
                     MaterialUtil.MakeDelegate(
@@ -414,23 +408,6 @@ namespace Squared.Illuminant {
                 }
             ));
 
-#if SDL2
-            materials.Add(IlluminantMaterials.ScreenSpaceGammaCompressedBitmap = new Squared.Render.EffectMaterial(
-                content.Load<Effect>("ScreenSpaceGammaCompressedBitmap"), "ScreenSpaceGammaCompressedBitmap"
-            ));
-
-            materials.Add(IlluminantMaterials.WorldSpaceGammaCompressedBitmap = new Squared.Render.EffectMaterial(
-                content.Load<Effect>("WorldSpaceGammaCompressedBitmap"), "WorldSpaceGammaCompressedBitmap"
-            ));
-
-            materials.Add(IlluminantMaterials.ScreenSpaceToneMappedBitmap = new Squared.Render.EffectMaterial(
-                content.Load<Effect>("ScreenSpaceToneMappedBitmap"), "ScreenSpaceToneMappedBitmap"
-            ));
-
-            materials.Add(IlluminantMaterials.WorldSpaceToneMappedBitmap = new Squared.Render.EffectMaterial(
-                content.Load<Effect>("WorldSpaceToneMappedBitmap"), "WorldSpaceToneMappedBitmap"
-            ));
-#else
             materials.Add(IlluminantMaterials.ScreenSpaceGammaCompressedBitmap = new Squared.Render.EffectMaterial(
                 content.Load<Effect>("HDRBitmap"), "ScreenSpaceGammaCompressedBitmap"
             ));
@@ -454,7 +431,6 @@ namespace Squared.Illuminant {
             materials.Add(IlluminantMaterials.WorldSpaceRampBitmap = new Squared.Render.EffectMaterial(
                 content.Load<Effect>("RampBitmap"), "WorldSpaceRampBitmap"
             ));
-#endif
 
             Environment = environment;
 
@@ -560,10 +536,6 @@ namespace Squared.Illuminant {
 
             foreach (var mi in PointLightMaterialsInner) {
                 mi.Effect.Parameters["LightNeutralColor"].SetValue(ls.NeutralColor);
-#if SDL2
-                // Only the RampTexture techniques have this parameter -flibit
-                if (mi.Effect.Parameters["RampTexture"] != null)
-#endif
                 mi.Effect.Parameters["RampTexture"].SetValue(ls.RampTexture);
 
                 var tsize = new Vector2(
@@ -1214,9 +1186,7 @@ namespace Squared.Illuminant {
         public Material VolumeFrontFace, VolumeTopFace;
         public Squared.Render.EffectMaterial ScreenSpaceGammaCompressedBitmap, WorldSpaceGammaCompressedBitmap;
         public Squared.Render.EffectMaterial ScreenSpaceToneMappedBitmap, WorldSpaceToneMappedBitmap;
-#if !SDL2
         public Squared.Render.EffectMaterial ScreenSpaceRampBitmap, WorldSpaceRampBitmap;
-#endif
 
         internal readonly Effect[] EffectsToSetGammaCompressionParametersOn;
         internal readonly Effect[] EffectsToSetToneMappingParametersOn;


### PR DESCRIPTION
This updates the FNA/SDL2 configuration for Illuminant, pulled from the latest EG2 revision.

On top of the new FNA.csproj, Illuminant in particular removes almost every SDL2-specific def, except for one related to the use of `Parallel` operations (Mono still doesn't like this).

This is meant to go hand-in-hand with the Squared FNA update.
